### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/app/src/main/java/com/thefinestartist/instatag/activities/CameraActivity.java
+++ b/app/src/main/java/com/thefinestartist/instatag/activities/CameraActivity.java
@@ -23,6 +23,8 @@ public class CameraActivity extends StatusBarTintActivity {
 
     protected static final int REQUEST_TAKE_PHOTO = 1234;
 
+    private final static String TAKING_PHOTO_PATH = "TAKING_PHOTO_PATH";
+
     private String mTakingPhotoPath;
     private File mTakingPhotoFile;
 
@@ -86,8 +88,6 @@ public class CameraActivity extends StatusBarTintActivity {
         mediaScanIntent.setData(contentUri);
         this.sendBroadcast(mediaScanIntent);
     }
-
-    private final static String TAKING_PHOTO_PATH = "TAKING_PHOTO_PATH";
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {

--- a/app/src/main/java/com/thefinestartist/instatag/activities/PhotoEditActivity.java
+++ b/app/src/main/java/com/thefinestartist/instatag/activities/PhotoEditActivity.java
@@ -27,6 +27,8 @@ public class PhotoEditActivity extends CameraActivity {
 
     protected static final int REQUEST_EDIT_PHOTO = 4321;
 
+    private final static String EDITING_PHOTO_PATH = "EDITING_PHOTO_PATH";
+
     private String mEditingPhotoPath;
     private File mEditingPhotoFile;
 
@@ -95,8 +97,6 @@ public class PhotoEditActivity extends CameraActivity {
         mediaScanIntent.setData(contentUri);
         this.sendBroadcast(mediaScanIntent);
     }
-
-    private final static String EDITING_PHOTO_PATH = "EDITING_PHOTO_PATH";
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {

--- a/app/src/main/java/com/thefinestartist/instatag/adapters/PhotoAdapter.java
+++ b/app/src/main/java/com/thefinestartist/instatag/adapters/PhotoAdapter.java
@@ -45,6 +45,8 @@ public class PhotoAdapter extends ArrayAdapter<PhotoItem> {
     private Context context;
     private int resourceId;
 
+    private int itemWidth, itemHeight;
+
     public PhotoAdapter(Context context, int resourceId, List<PhotoItem> items) {
         super(context, resourceId, items);
         this.context = context;
@@ -86,8 +88,6 @@ public class PhotoAdapter extends ArrayAdapter<PhotoItem> {
 
         return view;
     }
-
-    private int itemWidth, itemHeight;
 
     private int getItemWidth() {
         if (itemWidth == 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
