### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/com/thefinestartist/instatag/helpers/AdHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/AdHelper.java
@@ -13,6 +13,8 @@ import com.thefinestartist.instatag.R;
  */
 public class AdHelper {
 
+    private AdHelper() {}
+
     public static void loadBannerAd(AdView adView) {
         try {
             adView.loadAd(new AdRequest.Builder()

--- a/app/src/main/java/com/thefinestartist/instatag/helpers/DipPixelHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/DipPixelHelper.java
@@ -11,6 +11,8 @@ import android.util.TypedValue;
  */
 public class DipPixelHelper {
 
+    private DipPixelHelper() {}
+
     public static float getPixel(Context context, int dip) {
         Resources r = context.getResources();
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dip, r.getDisplayMetrics());

--- a/app/src/main/java/com/thefinestartist/instatag/helpers/MediaScanHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/MediaScanHelper.java
@@ -9,6 +9,8 @@ import android.net.Uri;
  */
 public class MediaScanHelper {
 
+    private MediaScanHelper() {}
+
     public static void scan(Context context, String path, MediaScannerConnection.OnScanCompletedListener listener) {
         MediaScannerConnection.scanFile(context, new String[]{path}, null, listener);
     }

--- a/app/src/main/java/com/thefinestartist/instatag/helpers/PhotoItemHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/PhotoItemHelper.java
@@ -9,6 +9,8 @@ import java.io.File;
  */
 public class PhotoItemHelper {
 
+    private PhotoItemHelper() {}
+
     public static void delete(PhotoItem item) {
         try {
             File file = new File(item.getFilePath());

--- a/app/src/main/java/com/thefinestartist/instatag/helpers/ScreenHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/ScreenHelper.java
@@ -27,6 +27,8 @@ import android.view.WindowManager;
 
 public class ScreenHelper {
 
+    private ScreenHelper() {}
+
     @SuppressWarnings("deprecation")
     @SuppressLint("NewApi")
     public static int getWidth(Context context) {

--- a/app/src/main/java/com/thefinestartist/instatag/helpers/ShareHelper.java
+++ b/app/src/main/java/com/thefinestartist/instatag/helpers/ShareHelper.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 public class ShareHelper {
 
+    private ShareHelper() {}
+
     public static void share(Activity activity, PhotoItem item) {
         getShareActions(activity, item).title("Share Photo").grid().build().show();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
